### PR TITLE
compositor: remove tw_surface_mananger

### DIFF
--- a/include/taiwins/objects/compositor.h
+++ b/include/taiwins/objects/compositor.h
@@ -24,6 +24,7 @@
 
 #include <wayland-server-core.h>
 #include <wayland-server.h>
+#include "utils.h"
 
 #ifdef  __cplusplus
 extern "C" {
@@ -38,8 +39,9 @@ struct tw_compositor {
 	struct wl_signal surface_created;
 	struct wl_signal region_created;
 	struct wl_signal subsurface_created;
-	//TODO remove this, should be in surface itself.
-	struct wl_signal surface_dirty;
+
+        /** allocator for objects */
+	const struct tw_allocator *obj_alloc;
 
 	struct wl_listener destroy_listener;
 };

--- a/include/taiwins/objects/compositor.h
+++ b/include/taiwins/objects/compositor.h
@@ -35,9 +35,11 @@ struct tw_compositor {
 	struct wl_list clients;
 	struct wl_list subcomp_clients;
 
-	struct wl_signal surface_create;
-	struct wl_signal region_create;
-	struct wl_signal subsurface_get;
+	struct wl_signal surface_created;
+	struct wl_signal region_created;
+	struct wl_signal subsurface_created;
+	//TODO remove this, should be in surface itself.
+	struct wl_signal surface_dirty;
 
 	struct wl_listener destroy_listener;
 };

--- a/include/taiwins/objects/egl.h
+++ b/include/taiwins/objects/egl.h
@@ -107,6 +107,9 @@ tw_egl_buffer_age(struct tw_egl *egl, EGLSurface surface);
 bool
 tw_egl_bind_wl_display(struct tw_egl *egl, struct wl_display *display);
 
+bool
+tw_egl_destroy_image(struct tw_egl *egl, EGLImageKHR image);
+
 EGLImageKHR
 tw_egl_import_wl_drm_image(struct tw_egl *egl, struct wl_resource *data,
                            EGLint *fmt, int *width, int *height,

--- a/include/taiwins/objects/output.h
+++ b/include/taiwins/objects/output.h
@@ -58,6 +58,9 @@ tw_output_create(struct wl_display *display);
 void
 tw_output_destroy(struct tw_output *output);
 
+struct tw_output *
+tw_output_from_resource(struct wl_resource *resource);
+
 void
 tw_output_set_name(struct tw_output *output, const char *name);
 

--- a/include/taiwins/objects/surface.h
+++ b/include/taiwins/objects/surface.h
@@ -31,6 +31,7 @@
 
 #include "matrix.h"
 #include "plane.h"
+#include "utils.h"
 
 #ifdef  __cplusplus
 extern "C" {
@@ -121,7 +122,8 @@ struct tw_view {
 struct tw_subsurface;
 struct tw_surface {
 	struct wl_resource *resource;
-        /** the tw_surface::buffer is used to present; should stay available
+	const struct tw_allocator *alloc;
+	/** the tw_surface::buffer is used to present; should stay available
          * from imported to destroy of the surface
          */
 	struct tw_surface_buffer buffer;
@@ -223,7 +225,8 @@ struct tw_region {
 };
 
 struct tw_surface*
-tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id);
+tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id,
+                  const struct tw_allocator *alloc);
 
 struct tw_surface *
 tw_surface_from_resource(struct wl_resource *wl_surface);

--- a/include/taiwins/objects/surface.h
+++ b/include/taiwins/objects/surface.h
@@ -136,29 +136,11 @@ struct tw_surface {
 	struct tw_view *pending, *current, *previous;
 	struct tw_view surface_states[3];
 
-	//TODO: make a pointer of render_data which contains all of these
-	//(damages), clip, output, created on surface creation.
-#ifdef TW_OVERLAY_PLANE
-	/* previously I solved the overlapping output damage by giving
-	 * the copy to all outputs. Not sure if there is a better
-	 * solution. If we do not do plane assignment at all. Maybe
-	 * except cursor, we can directly reduce the damages to the
-	 * output.
-	 */
-	pixman_region32_t output_damages[32];
-#endif
-	/** the part is not occluded by any other surface */
-	pixman_region32_t clip;
-
-	int32_t output; /**< the primary output for this surface */
-	uint32_t output_mask; /**< the output it touches */
-
 	/**
 	 * many types may need to use one of the links, eg: backend_ouput,
 	 * layer, compositor, input. Plane.
 	 */
 	struct wl_list links[MAX_VIEW_LINKS];
-
         struct wl_list layer_link;
 
 	struct wl_list frame_callbacks;

--- a/include/taiwins/objects/surface.h
+++ b/include/taiwins/objects/surface.h
@@ -198,12 +198,14 @@ struct tw_subsurface {
 	struct wl_listener surface_destroyed;
 	int32_t sx, sy;
 	bool sync;
+	const struct tw_allocator *alloc;
 };
 
 struct tw_region {
 	struct wl_resource *resource;
 	pixman_region32_t region;
 	struct wl_signal destroy;
+	const struct tw_allocator *alloc;
 };
 
 struct tw_surface*
@@ -264,14 +266,15 @@ struct tw_subsurface *
 tw_surface_get_subsurface(struct tw_surface *surf);
 
 struct tw_subsurface *
-tw_subsurface_create(struct wl_client *client, uint32_t version,
-                     uint32_t id, struct tw_surface *surface,
-                     struct tw_surface *parent);
+tw_subsurface_create(struct wl_client *client, uint32_t version, uint32_t id,
+                     struct tw_surface *surface, struct tw_surface *parent,
+                     const struct tw_allocator *alloc);
 void
 tw_subsurface_update_pos(struct tw_subsurface *sub,
                          int32_t sx, int32_t sy);
 struct tw_region *
-tw_region_create(struct wl_client *client, uint32_t version, uint32_t id);
+tw_region_create(struct wl_client *client, uint32_t version, uint32_t id,
+                 const struct tw_allocator *alloc);
 
 struct tw_region *
 tw_region_from_resource(struct wl_resource *wl_region);

--- a/include/taiwins/objects/utils.h
+++ b/include/taiwins/objects/utils.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <time.h>
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 
@@ -71,6 +72,12 @@ tw_match_wl_resource_client(struct wl_resource *a, struct wl_resource *b);
 			free(obj); \
 		ret; \
 	})
+
+uint32_t
+tw_get_time_msec(void);
+
+uint64_t
+tw_timespec_to_msec(const struct timespec *spec);
 
 #ifdef  __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('twobjects', 'c',
-	version : '0.1.0',
+	version : '0.1.1',
 	default_options: [
 	  'warning_level=2', #warn level has to be 2 to get wlroots compiles
 	  'c_std=gnu11',

--- a/objects/buffer.c
+++ b/objects/buffer.c
@@ -39,17 +39,16 @@ tw_surface_buffer_update(struct tw_surface_buffer *buffer,
 	struct tw_event_buffer_uploading event;
 	//compare if resource is a wl_buffer
 	struct tw_surface *surface = wl_container_of(buffer, surface, buffer);
-	struct tw_surface_manager *manager = surface->manager;
 	void *user_data;
 	bool ret = false;
 
-	if (manager && manager->buffer_import.buffer_import) {
+	if (buffer->buffer_import.buffer_import) {
 		event.wl_buffer = resource;
 		event.damages = damage;
 		event.buffer = buffer;
 		event.new_upload = false;
-		user_data = manager->buffer_import.callback;
-		ret = manager->buffer_import.buffer_import(&event, user_data);
+		user_data = buffer->buffer_import.callback;
+		ret = buffer->buffer_import.buffer_import(&event, user_data);
 	}
 	//if updating failed, nothing changes.
 	if (ret)
@@ -63,16 +62,15 @@ tw_surface_buffer_new(struct tw_surface_buffer *buffer,
 {
 	struct tw_event_buffer_uploading event = {0};
 	struct tw_surface *surface = wl_container_of(buffer, surface, buffer);
-	struct tw_surface_manager *manager = surface->manager;
 	void *user_data;
 
-	if (manager && manager->buffer_import.buffer_import) {
+	if (buffer->buffer_import.buffer_import) {
 		event.new_upload = true;
 		event.wl_buffer = resource;
 		event.damages = NULL;
 		event.buffer = buffer;
-		user_data = manager->buffer_import.callback;
-		manager->buffer_import.buffer_import(&event, user_data);
+		user_data = buffer->buffer_import.callback;
+		buffer->buffer_import.buffer_import(&event, user_data);
 	}
 	if (tw_surface_has_texture(surface))
 		buffer->resource = resource;

--- a/objects/compositor.c
+++ b/objects/compositor.c
@@ -124,7 +124,8 @@ create_wl_surface(struct wl_client *client,
 	                               &compositor_impl));
 	compositor = wl_resource_get_user_data(resource);
 
-	surface = tw_surface_create(client, SURFACE_VERSION, id);
+	surface = tw_surface_create(client, SURFACE_VERSION, id,
+	                            compositor->obj_alloc);
 	if (surface)
 		wl_signal_emit(&compositor->surface_created, surface);
 }
@@ -213,6 +214,7 @@ tw_compositor_init(struct tw_compositor *compositor,
 	}
 	wl_list_init(&compositor->destroy_listener.link);
 	compositor->destroy_listener.notify = destroy_tw_compositor;
+	compositor->obj_alloc = NULL;
 
 	wl_signal_init(&compositor->surface_created);
 	wl_signal_init(&compositor->region_created);

--- a/objects/compositor.c
+++ b/objects/compositor.c
@@ -30,6 +30,7 @@
 
 #include <taiwins/objects/utils.h>
 #include <taiwins/objects/compositor.h>
+#include <taiwins/objects/surface.h>
 
 #define COMPOSITOR_VERSION 4
 #define SUBCOMPOSITOR_VERSION 1
@@ -58,21 +59,21 @@ get_wl_subsurface(struct wl_client *client,
                   struct wl_resource *parent)
 {
 	struct tw_compositor *compositor;
-	struct tw_event_get_wl_subsurface event = {
-		.surface = surface,
-		.parent_surface = parent,
-		.client = client,
-		.version = SUBSURFACE_VERSION,
-		.id = id,
-	};
+	struct tw_subsurface *subsurface;
+
 	assert(wl_resource_instance_of(resource, &wl_subcompositor_interface,
 	                               &subcompositor_impl));
 	compositor = wl_resource_get_user_data(resource);
+	subsurface = tw_subsurface_create(client, SUBSURFACE_VERSION, id,
+	                                  tw_surface_from_resource(surface),
+	                                  tw_surface_from_resource(parent));
+	if (subsurface)
+		wl_signal_emit(&compositor->subsurface_created, subsurface);
 
         //subcompositor is deeply linked to actual surface implementation. Here
 	//we cannot directly do anything except making a signal proxy.
 	//a subsurface resource is expected to be created in the event.
-	wl_signal_emit(&compositor->subsurface_get, &event);
+	/* wl_signal_emit(&compositor->subsurface_get, &event); */
 }
 
 static const struct wl_subcompositor_interface subcompositor_impl = {
@@ -117,16 +118,15 @@ create_wl_surface(struct wl_client *client,
                   uint32_t id)
 {
 	struct tw_compositor *compositor;
-	struct tw_event_new_wl_surface event = {
-		resource, client,
-		SURFACE_VERSION,
-		id,
-	};
+	struct tw_surface *surface;
 
 	assert(wl_resource_instance_of(resource, &wl_compositor_interface,
 	                               &compositor_impl));
 	compositor = wl_resource_get_user_data(resource);
-	wl_signal_emit(&compositor->surface_create, &event);
+
+	surface = tw_surface_create(client, SURFACE_VERSION, id);
+	if (surface)
+		wl_signal_emit(&compositor->surface_created, surface);
 }
 
 static void
@@ -135,16 +135,16 @@ create_wl_region(struct wl_client *client,
                  uint32_t id)
 {
 	struct tw_compositor *compositor;
-	struct tw_event_new_wl_region event = {
-		resource, client,
-		wl_resource_get_version(resource),
-		id,
-	};
+	struct tw_region *region;
 
 	assert(wl_resource_instance_of(resource, &wl_compositor_interface,
 	                               &compositor_impl));
 	compositor = wl_resource_get_user_data(resource);
-	wl_signal_emit(&compositor->region_create, &event);
+	region = tw_region_create(client, wl_resource_get_version(resource),
+	                          id);
+	if (region)
+		wl_signal_emit(&compositor->region_created, region);
+
 }
 
 static const struct wl_compositor_interface compositor_impl = {
@@ -214,9 +214,9 @@ tw_compositor_init(struct tw_compositor *compositor,
 	wl_list_init(&compositor->destroy_listener.link);
 	compositor->destroy_listener.notify = destroy_tw_compositor;
 
-	wl_signal_init(&compositor->surface_create);
-	wl_signal_init(&compositor->region_create);
-	wl_signal_init(&compositor->subsurface_get);
+	wl_signal_init(&compositor->surface_created);
+	wl_signal_init(&compositor->region_created);
+	wl_signal_init(&compositor->subsurface_created);
 	wl_list_init(&compositor->clients);
 	wl_list_init(&compositor->subcomp_clients);
 

--- a/objects/compositor.c
+++ b/objects/compositor.c
@@ -66,14 +66,10 @@ get_wl_subsurface(struct wl_client *client,
 	compositor = wl_resource_get_user_data(resource);
 	subsurface = tw_subsurface_create(client, SUBSURFACE_VERSION, id,
 	                                  tw_surface_from_resource(surface),
-	                                  tw_surface_from_resource(parent));
+	                                  tw_surface_from_resource(parent),
+	                                  compositor->obj_alloc);
 	if (subsurface)
 		wl_signal_emit(&compositor->subsurface_created, subsurface);
-
-        //subcompositor is deeply linked to actual surface implementation. Here
-	//we cannot directly do anything except making a signal proxy.
-	//a subsurface resource is expected to be created in the event.
-	/* wl_signal_emit(&compositor->subsurface_get, &event); */
 }
 
 static const struct wl_subcompositor_interface subcompositor_impl = {
@@ -142,7 +138,7 @@ create_wl_region(struct wl_client *client,
 	                               &compositor_impl));
 	compositor = wl_resource_get_user_data(resource);
 	region = tw_region_create(client, wl_resource_get_version(resource),
-	                          id);
+	                          id, compositor->obj_alloc);
 	if (region)
 		wl_signal_emit(&compositor->region_created, region);
 

--- a/objects/drm_formats.c
+++ b/objects/drm_formats.c
@@ -43,7 +43,7 @@ tw_drm_formats_fini(struct tw_drm_formats *formats)
 WL_EXPORT size_t
 tw_drm_formats_count(struct tw_drm_formats *formats)
 {
-	return formats->formats.size / sizeof(struct tw_drm_formats);
+	return formats->formats.size / sizeof(struct tw_drm_format);
 }
 
 WL_EXPORT bool

--- a/objects/egl.c
+++ b/objects/egl.c
@@ -551,6 +551,16 @@ tw_egl_bind_wl_display(struct tw_egl *egl, struct wl_display *display)
 	return false;
 }
 
+WL_EXPORT bool
+tw_egl_destroy_image(struct tw_egl *egl, EGLImageKHR image)
+{
+	if (!egl->funcs.destroy_image)
+		return false;
+	if (image == EGL_NO_IMAGE)
+		return true;
+	return egl->funcs.destroy_image(egl->display, image);
+}
+
 WL_EXPORT EGLImageKHR
 tw_egl_import_wl_drm_image(struct tw_egl *egl, struct wl_resource *data,
                            EGLint *fmt, int *width, int *height,

--- a/objects/egl.c
+++ b/objects/egl.c
@@ -648,7 +648,6 @@ prepare_egl_dmabuf_attributes(EGLint eglattrs[50],
 			eglattrs[atti++] = attr_names[i].mod_lo;
 			eglattrs[atti++] = attrs->modifier & 0xFFFFFFFF;
 			eglattrs[atti++] = attr_names[i].mod_hi;
-			eglattrs[atti++] = attr_names[i].mod_hi;
 			eglattrs[atti++] = attrs->modifier >> 32;
 		}
 	}

--- a/objects/meson.build
+++ b/objects/meson.build
@@ -71,6 +71,7 @@ lib_twobjects = both_libraries(
   c_args : twobject_cargs,
   dependencies : twobjects_deps,
   include_directories : twobjects_inc,
+  version: meson.project_version(),
   install : true,
   )
 

--- a/objects/region.c
+++ b/objects/region.c
@@ -90,13 +90,14 @@ tw_region_from_resource(struct wl_resource *wl_region)
 }
 
 WL_EXPORT struct tw_region *
-tw_region_create(struct wl_client *client, uint32_t version, uint32_t id)
+tw_region_create(struct wl_client *client, uint32_t ver, uint32_t id,
+                 const struct tw_allocator *alloc)
 {
 	struct wl_resource *resource = NULL;
 	struct tw_region *tw_region = NULL;
 
-	if (!tw_create_wl_resource_for_obj(resource, tw_region, client, id,
-	                                   version, wl_region_interface)) {
+	if (!tw_alloc_wl_resource_for_obj(resource, tw_region, client, id, ver,
+	                                  wl_region_interface, alloc)) {
 		wl_client_post_no_memory(client);
 		return NULL;
 	}

--- a/objects/region.c
+++ b/objects/region.c
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <wayland-server-core.h>
 #include <wayland-server-protocol.h>
 #include <wayland-server.h>
 
@@ -74,10 +75,8 @@ static void
 region_destroy_resource(struct wl_resource *resource)
 {
 	struct tw_region *region = tw_region_from_resource(resource);
-	if (region->manager)
-		wl_signal_emit(&region->manager->region_destroy_signal,
-		               region);
 
+	wl_signal_emit(&region->destroy, region);
 	pixman_region32_fini(&region->region);
 	free(region);
 }
@@ -91,8 +90,7 @@ tw_region_from_resource(struct wl_resource *wl_region)
 }
 
 WL_EXPORT struct tw_region *
-tw_region_create(struct wl_client *client, uint32_t version, uint32_t id,
-                 struct tw_surface_manager *manager)
+tw_region_create(struct wl_client *client, uint32_t version, uint32_t id)
 {
 	struct wl_resource *resource = NULL;
 	struct tw_region *tw_region = NULL;
@@ -102,10 +100,10 @@ tw_region_create(struct wl_client *client, uint32_t version, uint32_t id,
 		wl_client_post_no_memory(client);
 		return NULL;
 	}
-	tw_region->manager = manager;
 	wl_resource_set_implementation(resource, &region_impl, tw_region,
 	                               region_destroy_resource);
 	tw_region->resource = resource;
+	wl_signal_init(&tw_region->destroy);
 	pixman_region32_init(&tw_region->region);
 	return tw_region;
 }

--- a/objects/seat/seat_keyboard.c
+++ b/objects/seat/seat_keyboard.c
@@ -308,5 +308,5 @@ tw_keyboard_notify_modifiers(struct tw_keyboard *keyboard,
 	if (keyboard->grab && keyboard->grab->impl->modifiers)
 		keyboard->grab->impl->modifiers(keyboard->grab,
 		                                mods_depressed, mods_latched,
-		                                mods_latched, group);
+		                                mods_locked, group);
 }

--- a/objects/subsurface.c
+++ b/objects/subsurface.c
@@ -242,15 +242,15 @@ notify_subsurface_surface_destroy(struct wl_listener *listener, void *data)
  ******************************************************************************/
 
 WL_EXPORT struct tw_subsurface *
-tw_subsurface_create(struct wl_client *client, uint32_t version,
-                     uint32_t id, struct tw_surface *surface,
-                     struct tw_surface *parent)
+tw_subsurface_create(struct wl_client *client, uint32_t ver, uint32_t id,
+                     struct tw_surface *surface, struct tw_surface *parent,
+                     const struct tw_allocator *alloc)
 {
 	struct tw_subsurface *subsurface = NULL;
 	struct wl_resource *resource = NULL;
 
-	if (!tw_create_wl_resource_for_obj(resource, subsurface, client, id,
-	                                   version, wl_subsurface_interface)) {
+	if (!tw_alloc_wl_resource_for_obj(resource, subsurface, client, id,ver,
+	                                  wl_subsurface_interface, alloc)) {
 		wl_client_post_no_memory(client);
 		return NULL;
 	}

--- a/objects/subsurface.c
+++ b/objects/subsurface.c
@@ -22,6 +22,7 @@
 #include <limits.h>
 #include <assert.h>
 #include <math.h>
+#include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <taiwins/objects/utils.h>
 #include <taiwins/objects/surface.h>
@@ -201,13 +202,10 @@ subsurface_unset_role(struct tw_subsurface *subsurface)
 static void
 subsurface_destroy(struct tw_subsurface *subsurface)
 {
-	struct tw_surface_manager *manager;
 	if (!subsurface)
 		return;
-	manager = subsurface->surface->manager;
-	if (manager)
-		wl_signal_emit(&manager->subsurface_destroy_signal,
-		               subsurface);
+
+	wl_signal_emit(&subsurface->destroy, subsurface);
 
 	wl_list_remove(&subsurface->surface_destroyed.link);
 	if (subsurface->parent) {
@@ -264,6 +262,7 @@ tw_subsurface_create(struct wl_client *client, uint32_t version,
 	subsurface->parent = parent;
 	subsurface_set_role(subsurface, surface);
 	// stacking order
+	wl_signal_init(&subsurface->destroy);
 	wl_list_init(&subsurface->parent_link);
 	wl_list_init(&subsurface->parent_pending_link);
 	wl_list_insert(parent->subsurfaces_pending.prev,
@@ -274,10 +273,6 @@ tw_subsurface_create(struct wl_client *client, uint32_t version,
 		notify_subsurface_surface_destroy;
 	wl_signal_add(&surface->events.destroy,
 	              &subsurface->surface_destroyed);
-
-	if (surface->manager)
-		wl_signal_emit(&surface->manager->subsurface_created_signal,
-		               subsurface);
 
 	return subsurface;
 }

--- a/objects/surface.c
+++ b/objects/surface.c
@@ -723,7 +723,6 @@ surface_destroy_resource(struct wl_resource *resource)
 	if (surface->buffer.resource)
 		tw_surface_buffer_release(&surface->buffer);
 
-	pixman_region32_fini(&surface->clip);
 	pixman_region32_fini(&surface->geometry.dirty);
 
 	assert(surface->alloc);
@@ -755,7 +754,6 @@ tw_surface_create(struct wl_client *client, uint32_t ver, uint32_t id,
 	wl_signal_init(&surface->events.frame);
 	wl_signal_init(&surface->events.dirty);
 	wl_signal_init(&surface->events.destroy);
-	pixman_region32_init(&surface->clip);
 	pixman_region32_init(&surface->geometry.dirty);
 
 	for (int i = 0; i < MAX_VIEW_LINKS; i++)

--- a/objects/surface.c
+++ b/objects/surface.c
@@ -726,18 +726,20 @@ surface_destroy_resource(struct wl_resource *resource)
 	pixman_region32_fini(&surface->clip);
 	pixman_region32_fini(&surface->geometry.dirty);
 
-	free(surface);
+	assert(surface->alloc);
+	surface->alloc->free(surface, &wl_surface_interface);
 }
 
 WL_EXPORT struct tw_surface *
-tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id)
+tw_surface_create(struct wl_client *client, uint32_t ver, uint32_t id,
+                  const struct tw_allocator *alloc)
 {
 	struct tw_view *view;
 	struct wl_resource *resource = NULL;
 	struct tw_surface *surface = NULL;
 
-	if (!tw_create_wl_resource_for_obj(resource, surface, client, id,
-	                                   version, wl_surface_interface)) {
+	if (!tw_alloc_wl_resource_for_obj(resource, surface, client, id, ver,
+	                                  wl_surface_interface, alloc)) {
 		wl_client_post_no_memory(client);
 		return NULL;
 	}

--- a/objects/surface.c
+++ b/objects/surface.c
@@ -36,18 +36,6 @@
 #define CALLBACK_VERSION 1
 #define SURFACE_VERSION 4
 
-/*
- * tasks tracking:
- * - surface set positon causes geometry dirty.
- * - subsurface implementation
- * - testing with a dummy surface
- * - subusrface as a role
- * - managing subsurface stacking order at commit
- * - managing subsurface position at commit
- * - TODO: test with subsurface
- * - TODO: `update_surface_damage` based on surface transformation.
- */
-
 /******************************************************************************
  * wl_surface implementation
  *****************************************************************************/
@@ -511,10 +499,8 @@ surface_commit_state(struct tw_surface *surface)
 	surface_update_geometry(surface);
 	surface_update_damage(surface);
 
-	if (surface->manager &&
-	    pixman_region32_not_empty(&surface->current->surface_damage))
-		wl_signal_emit(&surface->manager->surface_dirty_signal,
-		               surface);
+	if (pixman_region32_not_empty(&surface->current->surface_damage))
+		wl_signal_emit(&surface->events.dirty, surface);
 	//also commit the subsurface surface and
 	if (surface->role.commit)
 		surface->role.commit(surface);
@@ -688,9 +674,7 @@ tw_surface_dirty_geometry(struct tw_surface *surface)
 
 	wl_list_for_each(sub, &surface->subsurfaces, parent_link)
 		tw_surface_dirty_geometry(sub->surface);
-	if (surface->manager)
-		wl_signal_emit(&surface->manager->surface_dirty_signal,
-		               surface);
+	wl_signal_emit(&surface->events.dirty, surface);
 }
 
 WL_EXPORT void
@@ -718,9 +702,8 @@ surface_destroy_resource(struct wl_resource *resource)
 	struct tw_view *view;
 	struct tw_surface *surface = tw_surface_from_resource(resource);
 
-	if (surface->manager)
-		wl_signal_emit(&surface->manager->surface_destroy_signal,
-		               surface);
+	wl_signal_emit(&surface->events.destroy, surface);
+
 	for (int i = 0; i < MAX_VIEW_LINKS; i++)
 		wl_list_remove(&surface->links[i]);
 	wl_list_remove(&surface->layer_link);
@@ -743,14 +726,11 @@ surface_destroy_resource(struct wl_resource *resource)
 	pixman_region32_fini(&surface->clip);
 	pixman_region32_fini(&surface->geometry.dirty);
 
-	wl_signal_emit(&surface->events.destroy, surface);
-
 	free(surface);
 }
 
 WL_EXPORT struct tw_surface *
-tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id,
-                  struct tw_surface_manager *manager)
+tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id)
 {
 	struct tw_view *view;
 	struct wl_resource *resource = NULL;
@@ -764,7 +744,6 @@ tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id,
 	wl_resource_set_implementation(resource, &surface_impl, surface,
 	                               surface_destroy_resource);
 	//initializers
-	surface->manager = manager;
 	surface->resource = resource;
 	surface->is_mapped = false;
 	surface->pending = &surface->surface_states[0];
@@ -772,6 +751,7 @@ tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id,
 	surface->previous = &surface->surface_states[2];
 	wl_signal_init(&surface->events.commit);
 	wl_signal_init(&surface->events.frame);
+	wl_signal_init(&surface->events.dirty);
 	wl_signal_init(&surface->events.destroy);
 	pixman_region32_init(&surface->clip);
 	pixman_region32_init(&surface->geometry.dirty);
@@ -805,20 +785,5 @@ tw_surface_create(struct wl_client *client, uint32_t version, uint32_t id,
 	wl_list_init(&surface->frame_callbacks);
 	wl_list_init(&surface->layer_link);
 
-	if (manager)
-		wl_signal_emit(&manager->surface_created_signal, surface);
 	return surface;
-}
-
-WL_EXPORT void
-tw_surface_manager_init(struct tw_surface_manager *manager)
-{
-	wl_signal_init(&manager->surface_created_signal);
-	wl_signal_init(&manager->subsurface_created_signal);
-	wl_signal_init(&manager->region_created_signal);
-	wl_signal_init(&manager->surface_destroy_signal);
-	wl_signal_init(&manager->subsurface_destroy_signal);
-	wl_signal_init(&manager->region_destroy_signal);
-
-	wl_signal_init(&manager->surface_dirty_signal);
 }

--- a/objects/utils.c
+++ b/objects/utils.c
@@ -20,9 +20,28 @@
  */
 
 #include <assert.h>
+#include <stdlib.h>
 #include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <taiwins/objects/utils.h>
+#include <wayland-util.h>
+
+static void *
+tw_default_alloc(size_t size, const struct wl_interface *interface)
+{
+	return calloc(1, size);
+}
+
+static void
+tw_default_free(void *ptr, const struct wl_interface *interface)
+{
+	free(ptr);
+}
+
+const struct tw_allocator tw_default_allocator = {
+	.alloc = tw_default_alloc,
+	.free = tw_default_free,
+};
 
 WL_EXPORT void
 tw_signal_setup_listener(struct wl_signal *signal,

--- a/objects/utils.c
+++ b/objects/utils.c
@@ -113,3 +113,18 @@ tw_signal_emit_safe(struct wl_signal *signal, void *data)
 	wl_list_remove(&end.link);
 
 }
+
+uint64_t
+tw_timespec_to_msec(const struct timespec *spec)
+{
+	return (int64_t)spec->tv_sec * 1000 + spec->tv_nsec / 1000000;
+}
+
+uint32_t
+tw_get_time_msec(void)
+{
+	struct timespec now;
+
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return tw_timespec_to_msec(&now);
+}


### PR DESCRIPTION
tw_surface creation is directly handled by tw_compositor now. User do not need
to manually call tw_surface_create anymore.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>