### PR TITLE
eglmesaext: ubuntu 18.04 hasn't merge the bind_wl_display into eglext yet

### DIFF
--- a/include/taiwins/objects/egl.h
+++ b/include/taiwins/objects/egl.h
@@ -24,6 +24,7 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <EGL/eglmesaext.h>
 
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
This is a good solution if we want to be portable. Let's solve that later.

3 potential solutions here:
- hiding the EGL function pointers in the source file and include them using compiler flags.
- config.h that define if we have `eglmesaext.h`.
- add self declaration like weston does.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>